### PR TITLE
Use the same default flags as stdlib’s log I just think this is what most Go developers will expect; I know I did.

### DIFF
--- a/log/logging.go
+++ b/log/logging.go
@@ -57,7 +57,7 @@ const (
 	FlagsPrecisionTime = log.Lmicroseconds
 	FlagsLongFile      = log.Llongfile
 	FlagsShortFile     = log.Lshortfile
-	FlagsDefault       = FlagsNone
+	FlagsDefault       = log.LstdFlags
 )
 
 var (
@@ -88,7 +88,11 @@ func init() {
 		Level = LevelTrace
 	}
 
-	Flags, _ = strconv.Atoi(os.Getenv("LOG_FORMAT"))
+	var err error
+	Flags, err = strconv.Atoi(os.Getenv("LOG_FORMAT"))
+	if err != nil {
+		Flags = FlagsDefault
+	}
 
 	DefaultLogger = New()
 }

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Logging functions", func() {
 	BeforeEach(func() {
 		output = new(bytes.Buffer)
 		log.Level = log.LevelTrace
+		log.SetTimestampFlags(log.FlagsNone)
 		log.SetOutput(output)
 	})
 


### PR DESCRIPTION
@timehop/backend please :eyes: thanks!