### PR TITLE
Implement json formatting and static fields

### DIFF
--- a/log/log_suite_test.go
+++ b/log/log_suite_test.go
@@ -1,4 +1,4 @@
-package log_test
+package log
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/log/logging.go
+++ b/log/logging.go
@@ -90,16 +90,16 @@ func init() {
 	defaultOutput = os.Stdout
 
 	Level = LevelInfo
-	switch os.Getenv("LOG_LEVEL") {
-	case "FATAL":
+	switch LogLevelName(os.Getenv("LOG_LEVEL")) {
+	case LevelFatalName:
 		Level = LevelFatal
-	case "ERROR":
+	case LevelErrorName:
 		Level = LevelError
-	case "WARN":
+	case LevelWarnName:
 		Level = LevelWarn
-	case "DEBUG":
+	case LevelDebugName:
 		Level = LevelDebug
-	case "TRACE":
+	case LevelTraceName:
 		Level = LevelTrace
 	}
 

--- a/log/logging.go
+++ b/log/logging.go
@@ -244,23 +244,14 @@ func newLoggerStruct(format LogFormat, id string, staticKeysAndValues ...interfa
 
 		// Instead put them into the staticArgs
 		if defaultPrefix != "" {
-			// Try to interpret at json, to get structured data.
-			var prefixData map[string]interface{}
-			if err := json.Unmarshal([]byte(defaultPrefix), &prefixData); err == nil {
-				for key, value := range prefixData {
-					staticArgs[key] = fmt.Sprintf("%v", value)
-				}
-			} else {
-				// Oh well, just use it as a single item.
-				staticArgs["prefix"] = defaultPrefix
-			}
+			staticArgs["prefix"] = defaultPrefix
 		}
 	} else {
 		prefix = defaultPrefix
 		flags = Flags
 	}
 
-	// Do this after handling json prefix, cuz individual loggers should override
+	// Do this after handling prefix, so that individual loggers can override
 	// external env variable.
 	currentKey := ""
 	for i, arg := range staticKeysAndValues {

--- a/log/logging.go
+++ b/log/logging.go
@@ -301,7 +301,7 @@ func SanitizeFormat(format LogFormat) LogFormat {
 	} else {
 		// Whether it's explicitly a DefaultFormat, or it's an unrecognized value,
 		// try to take from env var.
-		envFormat := os.Getenv("GOLOG_DEFAULT_ENCODING")
+		envFormat := os.Getenv("LOG_ENCODING")
 		if envFormat == string(JsonFormat) || envFormat == string(PlainTextFormat) {
 			return LogFormat(envFormat)
 		}

--- a/log/logging.go
+++ b/log/logging.go
@@ -86,6 +86,12 @@ var (
 )
 
 func init() {
+	// Call a separate func to actually do anything so it can be tested. This
+	// function itself automatically gets called on package load.
+	initLogging()
+}
+
+func initLogging() {
 	defaultPrefix = os.Getenv("LOG_PREFIX")
 	defaultOutput = os.Stdout
 

--- a/log/logging.go
+++ b/log/logging.go
@@ -46,12 +46,12 @@ import (
 type LogLevel int
 
 const (
-	LevelFatal LogLevel = iota
-	LevelError
-	LevelWarn
-	LevelInfo
-	LevelDebug
-	LevelTrace
+	LevelFatal LogLevel = 0
+	LevelError LogLevel = 1
+	LevelWarn  LogLevel = 2
+	LevelInfo  LogLevel = 3
+	LevelDebug LogLevel = 4
+	LevelTrace LogLevel = 5
 )
 
 type LogLevelName string

--- a/log/logging.go
+++ b/log/logging.go
@@ -43,8 +43,10 @@ import (
 	"time"
 )
 
+type LogLevel int
+
 const (
-	LevelFatal = iota
+	LevelFatal LogLevel = iota
 	LevelError
 	LevelWarn
 	LevelInfo
@@ -74,7 +76,7 @@ const (
 )
 
 var (
-	Level int
+	Level LogLevel
 	Flags int
 
 	DefaultLogger *Logger
@@ -322,7 +324,7 @@ func NewWithID(id string) *Logger {
 // logger, which is a standard lib's *log.Logger instance.
 type Logger struct {
 	ID    string
-	Level int
+	level LogLevel
 
 	formatter  logFormatter
 	staticArgs map[string]string

--- a/log/logging.go
+++ b/log/logging.go
@@ -210,7 +210,7 @@ type LoggerInterface interface {
 	Trace(description string, keysAndValues ...interface{})
 	SetOutput(w io.Writer)
 	SetTimestampFlags(flags int)
-	SetField(name string, value interface{})
+	SetStaticField(name string, value interface{})
 }
 
 func NewLogger(format LogFormat, id string, staticKeysAndValues ...interface{}) LoggerInterface {
@@ -403,7 +403,8 @@ func (s *Logger) SetTimestampFlags(flags int) {
 	s.l.SetFlags(flags)
 }
 
-func (s *Logger) SetField(name string, value interface{}) {
+// Add a key/value field to every log line from this logger.
+func (s *Logger) SetStaticField(name string, value interface{}) {
 	s.staticArgs[name] = fmt.Sprintf("%v", value)
 }
 

--- a/log/logging.go
+++ b/log/logging.go
@@ -238,8 +238,8 @@ type LogFormat string
 
 const (
 	DefaultFormat   LogFormat = "" // Use env variable, defaulting to PlainTextFormat
-	PlainTextFormat           = "text"
-	JsonFormat                = "json"
+	PlainTextFormat LogFormat = "text"
+	JsonFormat      LogFormat = "json"
 )
 
 // New creates a new logger instance.

--- a/log/logging.go
+++ b/log/logging.go
@@ -89,6 +89,9 @@ func init() {
 	// Call a separate func to actually do anything so it can be tested. This
 	// function itself automatically gets called on package load.
 	initLogging()
+
+	// Setting up mockable fns is fine to do here, though.
+	osExit = os.Exit
 }
 
 func initLogging() {
@@ -136,7 +139,7 @@ func Fatal(id, description string, keysAndValues ...interface{}) {
 		return
 	}
 	DefaultLogger.logMessage(LevelFatalName, id, description, keysAndValues...)
-	os.Exit(1)
+	osExit(1)
 }
 
 // Error outputs an error message with an optional list of key/value pairs.
@@ -340,7 +343,7 @@ func (s *logger) Fatal(description string, keysAndValues ...interface{}) {
 		return
 	}
 	s.logMessage(LevelFatalName, s.id, description, keysAndValues...)
-	os.Exit(1)
+	osExit(1)
 }
 
 // Error outputs an error message with an optional list of key/value pairs.
@@ -532,3 +535,5 @@ type jsonLogEntry struct {
 	Message   string            `json:"msg,omitempty"`
 	Fields    map[string]string `json:"fields,omitempty"`
 }
+
+var osExit func(int)

--- a/log/logging.go
+++ b/log/logging.go
@@ -58,11 +58,11 @@ type LogLevelName string
 
 const (
 	LevelFatalName LogLevelName = "FATAL"
-	LevelErrorName              = "ERROR"
-	LevelWarnName               = "WARN"
-	LevelInfoName               = "INFO"
-	LevelDebugName              = "DEBUG"
-	LevelTraceName              = "TRACE"
+	LevelErrorName LogLevelName = "ERROR"
+	LevelWarnName  LogLevelName = "WARN"
+	LevelInfoName  LogLevelName = "INFO"
+	LevelDebugName LogLevelName = "DEBUG"
+	LevelTraceName LogLevelName = "TRACE"
 )
 
 const (

--- a/log/logging.go
+++ b/log/logging.go
@@ -455,9 +455,19 @@ func formatLogEventAsPlainText(flags int, id string, level LogLevelName, descrip
 	items = append(items, description)
 
 	if len(args)+len(staticFields) > 0 {
-		// Prefix with static fields.
+		// Prefix with static fields, but make sure to allow args to override static.
 		for key, value := range staticFields {
-			args = append([]interface{}{key, value}, args...)
+			var existsInArgs bool
+
+			for i, arg := range args {
+				if i%2 == 0 && key == arg {
+					existsInArgs = true
+				}
+			}
+
+			if !existsInArgs {
+				args = append([]interface{}{key, value}, args...)
+			}
 		}
 
 		items = append(items, expandKeyValuePairs(args))

--- a/log/logging.go
+++ b/log/logging.go
@@ -530,10 +530,8 @@ func formatLogEventAsJson(flags int, name string, level LogLevelName, msg string
 		entry.Fields[currentKey] = ""
 	}
 
-	encodedEntry, err := json.Marshal(entry)
-	if err != nil {
-		return fmt.Sprintf("{\"ts\": %v, \"msg\": \"failed to marshal log entry\"}", entry.Timestamp)
-	}
+	// log entry can't fail to marshal, it's just strings, so ignore error for 100% test coverage
+	encodedEntry, _ := json.Marshal(entry)
 
 	return string(encodedEntry)
 }

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -25,6 +25,37 @@ var _ = Describe("Logging functions", func() {
 		initLogging()
 	})
 
+	Describe("SetPrefix()", func() {
+		Context("When modifying existing prefix through package level fn", func() {
+			BeforeEach(func() {
+				os.Setenv("LOG_PREFIX", "env_prefix ")
+				initLogging()
+				SetPrefix("fn_prefix ")
+			})
+
+			Describe("DefaultLogger", func() {
+				It("should use the new prefix", func() {
+					output = new(bytes.Buffer)
+					SetOutput(output)
+
+					Error("id", "msg")
+					Expect(output.String()).To(Equal("fn_prefix ERROR | id | msg\n"))
+				})
+			})
+
+			Describe("New loggers", func() {
+				It("should use the new prefix", func() {
+					logger := New(Config{ID: "id"})
+					output = new(bytes.Buffer)
+					logger.SetOutput(output)
+
+					logger.Error("msg")
+					Expect(output.String()).To(Equal("fn_prefix ERROR | id | msg\n"))
+				})
+			})
+		})
+	})
+
 	Describe("init()", func() {
 		Context("When initialized with prefix set through env var", func() {
 			BeforeEach(func() {

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -34,6 +34,40 @@ var _ = Describe("Logging functions", func() {
 		}
 	})
 
+	Describe("SanitizeFormat()", func() {
+		Context("When called with a known format", func() {
+			It("returns that format", func() {
+				Expect(SanitizeFormat(PlainTextFormat)).To(Equal(PlainTextFormat))
+				Expect(SanitizeFormat(JsonFormat)).To(Equal(JsonFormat))
+			})
+		})
+
+		Context("When called with an unknown format", func() {
+			Context("And there's a default from env var", func() {
+				It("returns that default", func() {
+					os.Setenv("LOG_ENCODING", "json")
+					initLogging()
+
+					Expect(SanitizeFormat(LogFormat("whut"))).To(Equal(JsonFormat))
+
+					os.Setenv("LOG_ENCODING", "text")
+					initLogging()
+
+					Expect(SanitizeFormat(LogFormat("whut"))).To(Equal(PlainTextFormat))
+				})
+			})
+
+			Context("And there's no default from env var", func() {
+				It("returns global default", func() {
+					os.Setenv("LOG_ENCODING", "")
+					initLogging()
+
+					Expect(SanitizeFormat(LogFormat("whut"))).To(Equal(PlainTextFormat))
+				})
+			})
+		})
+	})
+
 	Describe("Fatal logging fns", func() {
 		Context("When logging level artificially set low", func() {
 			Describe("Package level Fatal()", func() {

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -1,114 +1,296 @@
-package log_test
+package log
 
 import (
 	"bytes"
+	"log"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/timehop/golog/log"
 )
 
 var _ = Describe("Logging functions", func() {
 	var output *bytes.Buffer
 
+	// Reset logging
 	BeforeEach(func() {
-		output = new(bytes.Buffer)
-		log.Level = log.LevelTrace
-		log.SetTimestampFlags(log.FlagsNone)
-		log.SetOutput(output)
+		os.Setenv("LOG_PREFIX", "")
+		os.Setenv("LOG_LEVEL", "")
+		os.Setenv("LOG_FORMAT", "0")
+		os.Setenv("LOG_ENCODING", "")
+
+		initLogging()
 	})
 
-	Describe(".Error", func() {
-		It("should print a message with ERROR prefix without ID", func() {
-			log.Error("", "Not all those who wander are lost.")
+	Describe("init()", func() {
+		Context("When initialized with prefix set through env var", func() {
+			BeforeEach(func() {
+				os.Setenv("LOG_PREFIX", "env_prefix ")
 
-			Expect(output.String()).To(Equal("ERROR | Not all those who wander are lost.\n"))
+				initLogging()
+				output = new(bytes.Buffer)
+				SetOutput(output)
+			})
+
+			It("should use the supplied prefix", func() {
+				Error("id", "msg")
+				Expect(output.String()).To(Equal("env_prefix ERROR | id | msg\n"))
+			})
 		})
 
-		It("should print a message with ERROR prefix and ID", func() {
-			log.Error("Bilbo", "Not all those who wander are lost.")
+		Context("When initialized with a format", func() {
+			BeforeEach(func() {
+				os.Setenv("LOG_FORMAT", strconv.FormatInt(log.Ldate|log.Lshortfile, 10))
 
-			Expect(output.String()).To(Equal("ERROR | Bilbo | Not all those who wander are lost.\n"))
+				initLogging()
+				output = new(bytes.Buffer)
+				SetOutput(output)
+			})
+
+			It("should log with that format", func() {
+				Error("id", "msg")
+				Expect(output.String()).To(Equal(time.Now().Format("2006/01/02") + " logging.go:456:  | ERROR | id | msg\n"))
+			})
 		})
 
-		It("should print a message with ERROR prefix and key values", func() {
-			log.Error("Bilbo", "Not all those who wander are lost.", "key", "value", "foo", "bar")
+		Context("When initialized with a log level set through env var", func() {
+			Context("Set to FATAL", func() {
+				BeforeEach(func() {
+					os.Setenv("LOG_LEVEL", "FATAL")
+					initLogging()
+					output = new(bytes.Buffer)
+					SetOutput(output)
+				})
 
-			Expect(output.String()).To(Equal("ERROR | Bilbo | Not all those who wander are lost. | key='value' foo='bar'\n"))
-		})
+				It("should not log lower levels", func() {
+					Error("id", "msg")
+					Warn("id", "msg")
+					Info("id", "msg")
+					Debug("id", "msg")
+					Trace("id", "msg")
 
-		It("should print a message with ERROR prefix and key values", func() {
-			log.Error("Bilbo", "Not all those who wander are lost.", "key", "value", "foo", "bar")
+					Expect(output.String()).To(BeEmpty())
+				})
+			})
 
-			Expect(output.String()).To(Equal("ERROR | Bilbo | Not all those who wander are lost. | key='value' foo='bar'\n"))
-		})
+			Context("Set to ERROR", func() {
+				BeforeEach(func() {
+					os.Setenv("LOG_LEVEL", "ERROR")
+					initLogging()
+					output = new(bytes.Buffer)
+					SetOutput(output)
+				})
 
-		It("should print a message with ERROR prefix and key/value pairs and a valueless key", func() {
-			log.Error("", "Not all those who wander are lost.", "key", "value", "foo")
+				It("should log higher levels", func() {
+					Error("id", "msg")
 
-			Expect(output.String()).To(Equal("ERROR | Not all those who wander are lost. | key='value' foo=\n"))
+					Expect(output.String()).ToNot(BeEmpty())
+				})
+
+				It("should not log lower levels", func() {
+					Warn("id", "msg")
+					Info("id", "msg")
+					Debug("id", "msg")
+					Trace("id", "msg")
+
+					Expect(output.String()).To(BeEmpty())
+				})
+			})
+
+			Context("Set to WARN", func() {
+				BeforeEach(func() {
+					os.Setenv("LOG_LEVEL", "WARN")
+					initLogging()
+					output = new(bytes.Buffer)
+					SetOutput(output)
+				})
+
+				It("should log higher levels", func() {
+					Error("id", "msg")
+					Warn("id", "msg")
+
+					Expect(output.String()).ToNot(BeEmpty())
+				})
+
+				It("should not log lower levels", func() {
+					Info("id", "msg")
+					Debug("id", "msg")
+					Trace("id", "msg")
+
+					Expect(output.String()).To(BeEmpty())
+				})
+			})
+
+			Context("Set to INFO", func() {
+				BeforeEach(func() {
+					os.Setenv("LOG_LEVEL", "INFO")
+					initLogging()
+					output = new(bytes.Buffer)
+					SetOutput(output)
+				})
+
+				It("should log higher levels", func() {
+					Error("id", "msg")
+					Warn("id", "msg")
+					Info("id", "msg")
+
+					Expect(output.String()).ToNot(BeEmpty())
+				})
+
+				It("should not log lower levels", func() {
+					Debug("id", "msg")
+					Trace("id", "msg")
+
+					Expect(output.String()).To(BeEmpty())
+				})
+			})
+
+			Context("Set to DEBUG", func() {
+				BeforeEach(func() {
+					os.Setenv("LOG_LEVEL", "DEBUG")
+					initLogging()
+					output = new(bytes.Buffer)
+					SetOutput(output)
+				})
+
+				It("should log higher levels", func() {
+					Error("id", "msg")
+					Warn("id", "msg")
+					Info("id", "msg")
+					Debug("id", "msg")
+
+					Expect(output.String()).ToNot(BeEmpty())
+				})
+
+				It("should not log lower levels", func() {
+					Trace("id", "msg")
+
+					Expect(output.String()).To(BeEmpty())
+				})
+			})
+
+			Context("Set to TRACE", func() {
+				BeforeEach(func() {
+					os.Setenv("LOG_LEVEL", "TRACE")
+					initLogging()
+					output = new(bytes.Buffer)
+					SetOutput(output)
+				})
+
+				It("should log higher levels", func() {
+					Error("id", "msg")
+					Warn("id", "msg")
+					Info("id", "msg")
+					Debug("id", "msg")
+					Trace("id", "msg")
+
+					Expect(output.String()).ToNot(BeEmpty())
+				})
+			})
 		})
 	})
 
-	Describe(".Warn", func() {
-		It("should print a formatted message with WARN prefix", func() {
-			log.Warn("", "Not all those who wander are lost.")
-
-			Expect(output.String()).To(Equal("WARN | Not all those who wander are lost.\n"))
+	Context("Using package level logging", func() {
+		BeforeEach(func() {
+			output = new(bytes.Buffer)
+			Level = LevelTrace
+			SetTimestampFlags(FlagsNone)
+			SetOutput(output)
 		})
 
-		It("should not output anything if log level is lower than LevelWarn", func() {
-			log.Level = log.LevelError
-			log.Warn("", "Not all those who wander are lost.")
+		Describe(".Error", func() {
+			It("should print a message with ERROR prefix without ID", func() {
+				Error("", "Not all those who wander are lost.")
 
-			Expect(output.String()).To(BeEmpty())
-		})
-	})
+				Expect(output.String()).To(Equal("ERROR | Not all those who wander are lost.\n"))
+			})
 
-	Describe(".Info", func() {
-		It("should print a formatted message with INFO prefix", func() {
-			log.Info("", "Not all those who wander are lost.")
+			It("should print a message with ERROR prefix and ID", func() {
+				Error("Bilbo", "Not all those who wander are lost.")
 
-			Expect(output.String()).To(Equal("INFO | Not all those who wander are lost.\n"))
-		})
+				Expect(output.String()).To(Equal("ERROR | Bilbo | Not all those who wander are lost.\n"))
+			})
 
-		It("should not output anything if log level is lower than LevelInfo", func() {
-			log.Level = log.LevelWarn
-			log.Info("", "Not all those who wander are lost.")
+			It("should print a message with ERROR prefix and key values", func() {
+				Error("Bilbo", "Not all those who wander are lost.", "key", "value", "foo", "bar")
 
-			Expect(output.String()).To(BeEmpty())
-		})
-	})
+				Expect(output.String()).To(Equal("ERROR | Bilbo | Not all those who wander are lost. | key='value' foo='bar'\n"))
+			})
 
-	Describe(".Debug", func() {
-		It("should print a formatted message with DEBUG prefix", func() {
-			log.Debug("", "Not all those who wander are lost.")
+			It("should print a message with ERROR prefix and key values", func() {
+				Error("Bilbo", "Not all those who wander are lost.", "key", "value", "foo", "bar")
 
-			Expect(output.String()).To(Equal("DEBUG | Not all those who wander are lost.\n"))
-		})
+				Expect(output.String()).To(Equal("ERROR | Bilbo | Not all those who wander are lost. | key='value' foo='bar'\n"))
+			})
 
-		It("should not output anything if log level is lower than LevelDebug", func() {
-			log.Level = log.LevelInfo
-			log.Debug("", "Not all those who wander are lost.")
+			It("should print a message with ERROR prefix and key/value pairs and a valueless key", func() {
+				Error("", "Not all those who wander are lost.", "key", "value", "foo")
 
-			Expect(output.String()).To(BeEmpty())
-		})
-	})
-
-	Describe(".Trace", func() {
-		It("should print a formatted message with TRACE prefix", func() {
-			log.Trace("", "Not all those who wander are lost.")
-
-			Expect(output.String()).To(Equal("TRACE | Not all those who wander are lost.\n"))
+				Expect(output.String()).To(Equal("ERROR | Not all those who wander are lost. | key='value' foo=\n"))
+			})
 		})
 
-		It("should not output anything if log level is lower than LevelTrace", func() {
-			log.Level = log.LevelInfo
-			log.Trace("", "Not all those who wander are lost.")
+		Describe(".Warn", func() {
+			It("should print a formatted message with WARN prefix", func() {
+				Warn("", "Not all those who wander are lost.")
 
-			Expect(output.String()).To(BeEmpty())
+				Expect(output.String()).To(Equal("WARN | Not all those who wander are lost.\n"))
+			})
+
+			It("should not output anything if log level is lower than LevelWarn", func() {
+				Level = LevelError
+				Warn("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(BeEmpty())
+			})
+		})
+
+		Describe(".Info", func() {
+			It("should print a formatted message with INFO prefix", func() {
+				Info("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(Equal("INFO | Not all those who wander are lost.\n"))
+			})
+
+			It("should not output anything if log level is lower than LevelInfo", func() {
+				Level = LevelWarn
+				Info("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(BeEmpty())
+			})
+		})
+
+		Describe(".Debug", func() {
+			It("should print a formatted message with DEBUG prefix", func() {
+				Debug("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(Equal("DEBUG | Not all those who wander are lost.\n"))
+			})
+
+			It("should not output anything if log level is lower than LevelDebug", func() {
+				Level = LevelInfo
+				Debug("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(BeEmpty())
+			})
+		})
+
+		Describe(".Trace", func() {
+			It("should print a formatted message with TRACE prefix", func() {
+				Trace("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(Equal("TRACE | Not all those who wander are lost.\n"))
+			})
+
+			It("should not output anything if log level is lower than LevelTrace", func() {
+				Level = LevelInfo
+				Trace("", "Not all those who wander are lost.")
+
+				Expect(output.String()).To(BeEmpty())
+			})
 		})
 	})
 })
@@ -117,9 +299,9 @@ var _ = Describe("Logger", func() {
 	Describe("#SetTimestampFlags", func() {
 		It("changes the output of the date", func() {
 			output := new(bytes.Buffer)
-			logger := log.New(log.Config{ID: "bilbo"})
-			logger.SetLevel(log.LevelDebug)
-			logger.SetTimestampFlags(log.FlagsDate)
+			logger := New(Config{ID: "bilbo"})
+			logger.SetLevel(LevelDebug)
+			logger.SetTimestampFlags(FlagsDate)
 			logger.SetOutput(output)
 
 			message := "Not all those who wander are lost."
@@ -130,7 +312,7 @@ var _ = Describe("Logger", func() {
 
 			// And now changing the flags...
 			output = new(bytes.Buffer)
-			logger.SetTimestampFlags(log.FlagsNone)
+			logger.SetTimestampFlags(FlagsNone)
 			logger.SetOutput(output)
 			logger.Debug(message)
 			out = output.String()

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Logging functions", func() {
 		It("should print a formatted message with WARN prefix", func() {
 			log.Warn("", "Not all those who wander are lost.")
 
-			Expect(output.String()).To(Equal("WARN  | Not all those who wander are lost.\n"))
+			Expect(output.String()).To(Equal("WARN | Not all those who wander are lost.\n"))
 		})
 
 		It("should not output anything if log level is lower than LevelWarn", func() {
@@ -71,7 +71,7 @@ var _ = Describe("Logging functions", func() {
 		It("should print a formatted message with INFO prefix", func() {
 			log.Info("", "Not all those who wander are lost.")
 
-			Expect(output.String()).To(Equal("INFO  | Not all those who wander are lost.\n"))
+			Expect(output.String()).To(Equal("INFO | Not all those who wander are lost.\n"))
 		})
 
 		It("should not output anything if log level is lower than LevelInfo", func() {
@@ -117,8 +117,8 @@ var _ = Describe("Logger", func() {
 	Describe("#SetTimestampFlags", func() {
 		It("changes the output of the date", func() {
 			output := new(bytes.Buffer)
-			logger := log.NewWithID("bilbo")
-			logger.Level = log.LevelDebug
+			logger := log.New(log.Config{ID: "bilbo"})
+			logger.SetLevel(log.LevelDebug)
 			logger.SetTimestampFlags(log.FlagsDate)
 			logger.SetOutput(output)
 

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -637,6 +637,179 @@ var _ = Describe("Logging functions", func() {
 		})
 	})
 
+	Context("Using logger logging fns", func() {
+		var logger Logger
+		var output *bytes.Buffer
+
+		BeforeEach(func() {
+			logger = New(Config{Format: JsonFormat})
+			output = new(bytes.Buffer)
+			logger.SetOutput(output)
+		})
+
+		Describe("Fatal", func() {
+			Context("Below level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelFatal)
+				})
+
+				It("should log", func() {
+					logger.Fatal("oh no")
+
+					var entry jsonLogEntry
+					Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+					Expect(entry.Level).To(Equal(LevelFatalName))
+				})
+			})
+
+			Context("Above level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LogLevel(-1))
+				})
+
+				It("should not log", func() {
+					logger.Fatal("oh no")
+					Expect(output.Len()).To(Equal(0))
+				})
+			})
+		})
+
+		Describe("Error", func() {
+			Context("Below level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelError)
+				})
+
+				It("should log", func() {
+					logger.Error("oh no")
+
+					var entry jsonLogEntry
+					Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+					Expect(entry.Level).To(Equal(LevelErrorName))
+				})
+			})
+
+			Context("Above level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelFatal)
+				})
+
+				It("should not log", func() {
+					logger.Error("oh no")
+					Expect(output.Len()).To(Equal(0))
+				})
+			})
+		})
+
+		Describe("Warn", func() {
+			Context("Below level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelWarn)
+				})
+
+				It("should log", func() {
+					logger.Warn("oh no")
+
+					var entry jsonLogEntry
+					Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+					Expect(entry.Level).To(Equal(LevelWarnName))
+				})
+			})
+
+			Context("Above level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelFatal)
+				})
+
+				It("should not log", func() {
+					logger.Warn("oh no")
+					Expect(output.Len()).To(Equal(0))
+				})
+			})
+		})
+
+		Describe("Info", func() {
+			Context("Below level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelInfo)
+				})
+
+				It("should log", func() {
+					logger.Info("oh no")
+
+					var entry jsonLogEntry
+					Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+					Expect(entry.Level).To(Equal(LevelInfoName))
+				})
+			})
+
+			Context("Above level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelFatal)
+				})
+
+				It("should not log", func() {
+					logger.Info("oh no")
+					Expect(output.Len()).To(Equal(0))
+				})
+			})
+		})
+
+		Describe("Debug", func() {
+			Context("Below level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelDebug)
+				})
+
+				It("should log", func() {
+					logger.Debug("oh no")
+
+					var entry jsonLogEntry
+					Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+					Expect(entry.Level).To(Equal(LevelDebugName))
+				})
+			})
+
+			Context("Above level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelFatal)
+				})
+
+				It("should not log", func() {
+					logger.Debug("oh no")
+					Expect(output.Len()).To(Equal(0))
+				})
+			})
+		})
+
+		Describe("Trace", func() {
+			Context("Below level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelTrace)
+				})
+
+				It("should log", func() {
+					logger.Trace("oh no")
+
+					var entry jsonLogEntry
+					Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+					Expect(entry.Level).To(Equal(LevelTraceName))
+				})
+			})
+
+			Context("Above level", func() {
+				BeforeEach(func() {
+					logger.SetLevel(LevelFatal)
+				})
+
+				It("should not log", func() {
+					logger.Trace("oh no")
+					Expect(output.Len()).To(Equal(0))
+				})
+			})
+		})
+	})
+
 	Context("Using package level logging", func() {
 		BeforeEach(func() {
 			output = new(bytes.Buffer)

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Logging functions", func() {
 
 			It("should log with that format", func() {
 				Error("id", "msg")
-				Expect(output.String()).To(Equal(time.Now().Format("2006/01/02") + " logging.go:458:  | ERROR | id | msg\n"))
+				Expect(output.String()).To(MatchRegexp("[0-9/]{10} logging.go:[0-9]+: +| ERROR | id | msg\n"))
 			})
 		})
 

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -27,10 +27,62 @@ var _ = Describe("Logging functions", func() {
 		initLogging()
 
 		didExit = false
+		exitCode = 0
 		osExit = func(code int) {
 			didExit = true
 			exitCode = code
 		}
+	})
+
+	Describe("Fatal logging fns", func() {
+		Context("When logging level artificially set low", func() {
+			Describe("Package level Fatal()", func() {
+				BeforeEach(func() {
+					initLogging()
+					Level = LogLevel(-1)
+
+					didExit = false
+					exitCode = 0
+					output = new(bytes.Buffer)
+					SetOutput(output)
+
+					Fatal("id", "msg")
+				})
+
+				It("should not log when called", func() {
+					Expect(output.String()).To(BeEmpty())
+				})
+
+				It("should not exit when called", func() {
+					Expect(didExit).To(BeFalse())
+					Expect(exitCode).To(Equal(0))
+				})
+			})
+
+			Describe("Logger Fatal()", func() {
+				BeforeEach(func() {
+					Level = LogLevel(-1)
+					logger := NewDefault()
+
+					output = new(bytes.Buffer)
+					logger.SetOutput(output)
+
+					didExit = false
+					exitCode = 0
+
+					logger.Fatal("msg")
+				})
+
+				It("should not log when called", func() {
+					Expect(output.String()).To(BeEmpty())
+				})
+
+				It("should not exit when called", func() {
+					Expect(didExit).To(BeFalse())
+					Expect(exitCode).To(Equal(0))
+				})
+			})
+		})
 	})
 
 	Describe("SetPrefix()", func() {

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"encoding/json"
 	"log"
 	"os"
 	"strconv"
@@ -32,6 +33,23 @@ var _ = Describe("Logging functions", func() {
 			didExit = true
 			exitCode = code
 		}
+	})
+
+	Describe("JsonFormat", func() {
+		Context("Default prefix is set", func() {
+			It("Uses the default prefix as a static field", func() {
+				os.Setenv("LOG_PREFIX", "default_prefix")
+				initLogging()
+
+				output := new(bytes.Buffer)
+				SetOutput(output)
+				New(Config{Format: JsonFormat}).Error("oh no")
+
+				var entry jsonLogEntry
+				Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+				Expect(entry.Fields).To(HaveKeyWithValue("prefix", "default_prefix"))
+			})
+		})
 	})
 
 	Describe("SanitizeFormat()", func() {

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -291,6 +291,37 @@ var _ = Describe("Logging functions", func() {
 				})
 			})
 		})
+
+		Describe("Setting static fields after creating logger", func() {
+			var output *bytes.Buffer
+
+			BeforeEach(func() {
+				logger = New(Config{Format: JsonFormat}, "old_static_field", "old_static_value")
+				output = new(bytes.Buffer)
+				logger.SetOutput(output)
+				logger.SetStaticField("new_static_field", "new_static_value")
+			})
+
+			It("uses the static fields when loggin", func() {
+				logger.Error("oh no")
+
+				var entry jsonLogEntry
+				Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+				Expect(entry.Fields).To(HaveKeyWithValue("old_static_field", "old_static_value"))
+				Expect(entry.Fields).To(HaveKeyWithValue("new_static_field", "new_static_value"))
+				Expect(len(entry.Fields)).To(Equal(2))
+			})
+
+			It("override the newly set static fields when logging", func() {
+				logger.Error("oh no", "new_static_field", "dynamic_value")
+
+				var entry jsonLogEntry
+				Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+				Expect(entry.Fields).To(HaveKeyWithValue("old_static_field", "old_static_value"))
+				Expect(entry.Fields).To(HaveKeyWithValue("new_static_field", "dynamic_value"))
+				Expect(len(entry.Fields)).To(Equal(2))
+			})
+		})
 	})
 
 	Describe("SanitizeFormat()", func() {

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -36,6 +36,45 @@ var _ = Describe("Logging functions", func() {
 	})
 
 	Describe("JsonFormat", func() {
+		Context("Logs a jsonLogEntry struct in json format", func() {
+			var timeBefore, timeAfter time.Time
+			var entry jsonLogEntry
+
+			BeforeEach(func() {
+				output := new(bytes.Buffer)
+				SetOutput(output)
+
+				timeBefore = time.Now()
+				New(Config{Format: JsonFormat, ID: "id"}).Error("oh no")
+				timeAfter = time.Now()
+
+				Expect(json.Unmarshal(output.Bytes(), &entry)).To(BeNil())
+			})
+
+			It("has a timestamp", func() {
+				timestamp, err := time.Parse("2006-01-02 15:04:05 -0700 MST", entry.Timestamp)
+				Expect(err).To(BeNil())
+				Expect(timestamp).To(BeTemporally(">=", timeBefore))
+				Expect(timestamp).To(BeTemporally("<=", timeAfter))
+			})
+
+			It("has a log level", func() {
+				Expect(entry.Level).To(Equal(LevelErrorName))
+			})
+
+			It("has a name", func() {
+				Expect(entry.Name).To(Equal("id"))
+			})
+
+			It("has a message", func() {
+				Expect(entry.Message).To(Equal("oh no"))
+			})
+
+			It("has fields", func() {
+				Expect(entry.Fields).To(BeEmpty())
+			})
+		})
+
 		Context("Default prefix is set", func() {
 			It("Uses the default prefix as a static field", func() {
 				os.Setenv("LOG_PREFIX", "default_prefix")


### PR DESCRIPTION
1. **static fields**: when creating a logger, any fields specified will be logged on every line using that logger. Useful for making a logger per request, to log request-global things like RequestID, UserID, etc.
1. **json format**: optionally specify `JsonFormat` for a logger, to output a json blob per log line. This allows structured data to be extracted much more reliably than regex parsing, which breaks on so many scenarios.
1. **explicit/implicit format**: when creating a logger, you can specify `DefaultFormat` (default for old, deprecated `New` fns), and it uses an env variable to choose `PlainTextFormat` or `JsonFormat`, defaulting to plain text. This allows a user to have local development default to plain text, but on the server use json, for log aggregation.

Example of `PlainTextFormat`:
```
2015/06/30 16:11:07 | INFO  | SetupCaches | Cache initialized. | name='accounts'
```

Example of `JsonFormat`:
```
{"ts":"2015-06-30 15:36:52.649267033 -0400 EDT","lvl":"INFO","name":"SetupCaches","msg":"Cache initialized.","fields":{"name":"accounts"}}
```

@kjsteuer @kevin-cantwell @biasedbit @bdotdub 