### PR TITLE
Simplify Interface by removing ID as explicit arg

### DIFF
--- a/log/logging.go
+++ b/log/logging.go
@@ -76,9 +76,6 @@ const (
 )
 
 var (
-	Level LogLevel
-	Flags int
-
 	DefaultLogger Logger
 
 	defaultPrefix string
@@ -98,27 +95,28 @@ func initLogging() {
 	defaultPrefix = os.Getenv("LOG_PREFIX")
 	defaultOutput = os.Stdout
 
-	Level = LevelInfo
-	switch LogLevelName(os.Getenv("LOG_LEVEL")) {
-	case LevelFatalName:
-		Level = LevelFatal
-	case LevelErrorName:
-		Level = LevelError
-	case LevelWarnName:
-		Level = LevelWarn
-	case LevelDebugName:
-		Level = LevelDebug
-	case LevelTraceName:
-		Level = LevelTrace
-	}
-
-	var err error
-	Flags, err = strconv.Atoi(os.Getenv("LOG_FORMAT"))
-	if err != nil {
-		Flags = FlagsDefault
-	}
-
 	DefaultLogger = NewDefault()
+
+	level := LevelInfo
+	switch LogLevelName(os.Getenv("LOG_LEVEL")) {
+	case levelFatalName:
+		level = LevelFatal
+	case levelErrorName:
+		level = LevelError
+	case levelWarnName:
+		level = LevelWarn
+	case levelDebugName:
+		level = LevelDebug
+	case levelTraceName:
+		level = LevelTrace
+	}
+	DefaultLogger.SetLevel(level)
+
+	if flags, err := strconv.Atoi(os.Getenv("LOG_FORMAT")); err != nil {
+		DefaultLogger.SetFlags(FlagsDefault)
+	} else {
+		DefaultLogger.SetFlags(flags)
+	}
 }
 
 // Changes the global prefix for all log statements.
@@ -135,19 +133,14 @@ func SetPrefix(prefix string) {
 // Fatal outputs a severe error message just before terminating the process.
 // Use judiciously.
 func Fatal(id, description string, keysAndValues ...interface{}) {
-	if Level < LevelFatal {
-		return
-	}
-	DefaultLogger.logMessage(LevelFatalName, id, description, keysAndValues...)
-	osExit(1)
+	keysAndValues = append([]interface{}{"id", id}, keysAndValues)
+	DefaultLogger.Fatal(description, keysAndValues...)
 }
 
 // Error outputs an error message with an optional list of key/value pairs.
 func Error(id, description string, keysAndValues ...interface{}) {
-	if Level < LevelError {
-		return
-	}
-	DefaultLogger.logMessage(LevelErrorName, id, description, keysAndValues...)
+	keysAndValues = append([]interface{}{"id", id}, keysAndValues)
+	DefaultLogger.Error(description, keysAndValues...)
 }
 
 // Warn outputs a warning message with an optional list of key/value pairs.
@@ -155,10 +148,8 @@ func Error(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelWarn, calling this method will yield no
 // side effects.
 func Warn(id, description string, keysAndValues ...interface{}) {
-	if Level < LevelWarn {
-		return
-	}
-	DefaultLogger.logMessage(LevelWarnName, id, description, keysAndValues...)
+	keysAndValues = append([]interface{}{"id", id}, keysAndValues)
+	DefaultLogger.Warn(description, keysAndValues...)
 }
 
 // Info outputs an info message with an optional list of key/value pairs.
@@ -166,10 +157,8 @@ func Warn(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelInfo, calling this method will yield no
 // side effects.
 func Info(id, description string, keysAndValues ...interface{}) {
-	if Level < LevelInfo {
-		return
-	}
-	DefaultLogger.logMessage(LevelInfoName, id, description, keysAndValues...)
+	keysAndValues = append([]interface{}{"id", id}, keysAndValues)
+	DefaultLogger.Info(description, keysAndValues...)
 }
 
 // Debug outputs an info message with an optional list of key/value pairs.
@@ -177,10 +166,8 @@ func Info(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelDebug, calling this method will yield no
 // side effects.
 func Debug(id, description string, keysAndValues ...interface{}) {
-	if Level < LevelDebug {
-		return
-	}
-	DefaultLogger.logMessage(LevelDebugName, id, description, keysAndValues...)
+	keysAndValues = append([]interface{}{"id", id}, keysAndValues)
+	DefaultLogger.Debug(description, keysAndValues...)
 }
 
 // Trace outputs an info message with an optional list of key/value pairs.
@@ -188,10 +175,12 @@ func Debug(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelTrace, calling this method will yield no
 // side effects.
 func Trace(id, description string, keysAndValues ...interface{}) {
-	if Level < LevelTrace {
-		return
-	}
-	DefaultLogger.logMessage(LevelTraceName, id, description, keysAndValues...)
+	keysAndValues = append([]interface{}{"id", id}, keysAndValues)
+	DefaultLogger.Trace(description, keysAndValues...)
+}
+
+func SetLevel(level LogLevel) {
+	DefaultLogger.SetLevel(level)
 }
 
 // SetOutput sets the output destination for the default logger.
@@ -224,8 +213,6 @@ type Logger interface {
 	SetOutput(w io.Writer)
 	SetTimestampFlags(flags int)
 	SetStaticField(name string, value interface{})
-
-	logMessage(level LogLevelName, id string, description string, keysAndValues ...interface{})
 }
 
 // Logger config. Default/unset values for each attribute are safe.
@@ -268,6 +255,12 @@ func New(conf Config, staticKeysAndValues ...interface{}) Logger {
 		flags = Flags
 	}
 
+	// Set 'ID' config as a static field, but before reading the varargs suplied
+	// fields, so that they can override the config.
+	if conf.ID != "" {
+		staticArgs["id"] = conf.ID
+	}
+
 	// Do this after handling prefix, so that individual loggers can override
 	// external env variable.
 	currentKey := ""
@@ -286,7 +279,6 @@ func New(conf Config, staticKeysAndValues ...interface{}) Logger {
 	}
 
 	return &logger{
-		id:    conf.ID,
 		level: Level,
 
 		formatLogEvent: formatter,
@@ -326,7 +318,6 @@ func SanitizeFormat(format LogFormat) LogFormat {
 // with inferior severity will yield no effect) and wraps the underlying
 // logger, which is a standard lib's *log.Logger instance.
 type logger struct {
-	id    string
 	level LogLevel
 
 	formatLogEvent formatLogEvent
@@ -342,7 +333,7 @@ func (s *logger) Fatal(description string, keysAndValues ...interface{}) {
 	if s.level < LevelFatal {
 		return
 	}
-	s.logMessage(LevelFatalName, s.id, description, keysAndValues...)
+	s.logMessage(LevelFatalName, description, keysAndValues...)
 	osExit(1)
 }
 
@@ -351,7 +342,7 @@ func (s *logger) Error(description string, keysAndValues ...interface{}) {
 	if s.level < LevelError {
 		return
 	}
-	s.logMessage(LevelErrorName, s.id, description, keysAndValues...)
+	s.logMessage(LevelErrorName, description, keysAndValues...)
 }
 
 // Warn outputs a warning message with an optional list of key/value pairs.
@@ -362,7 +353,7 @@ func (s *logger) Warn(description string, keysAndValues ...interface{}) {
 	if s.level < LevelWarn {
 		return
 	}
-	s.logMessage(LevelWarnName, s.id, description, keysAndValues...)
+	s.logMessage(LevelWarnName, description, keysAndValues...)
 }
 
 // Info outputs an info message with an optional list of key/value pairs.
@@ -373,7 +364,7 @@ func (s *logger) Info(description string, keysAndValues ...interface{}) {
 	if s.level < LevelInfo {
 		return
 	}
-	s.logMessage(LevelInfoName, s.id, description, keysAndValues...)
+	s.logMessage(LevelInfoName, description, keysAndValues...)
 }
 
 // Debug outputs an info message with an optional list of key/value pairs.
@@ -384,7 +375,7 @@ func (s *logger) Debug(description string, keysAndValues ...interface{}) {
 	if s.level < LevelDebug {
 		return
 	}
-	s.logMessage(LevelDebugName, s.id, description, keysAndValues...)
+	s.logMessage(LevelDebugName, description, keysAndValues...)
 }
 
 // Trace outputs an info message with an optional list of key/value pairs.
@@ -395,11 +386,12 @@ func (s *logger) Trace(description string, keysAndValues ...interface{}) {
 	if s.level < LevelTrace {
 		return
 	}
-	s.logMessage(LevelTraceName, s.id, description, keysAndValues...)
+	s.logMessage(LevelTraceName, description, keysAndValues...)
 }
 
-func (s *logger) logMessage(level LogLevelName, id string, description string, keysAndValues ...interface{}) {
-	msg := s.formatLogEvent(s.flags, id, level, description, s.staticArgs, keysAndValues...)
+func (s *logger) logMessage(level LogLevelName, description string, keysAndValues ...interface{}) {
+	fmt.Printf("formatting with ars %v, keysvals %v", s.staticArgs, keysAndValues)
+	msg := s.formatLogEvent(s.flags, level, description, s.staticArgs, keysAndValues...)
 	s.l.Println(msg)
 }
 
@@ -427,7 +419,6 @@ func (s *logger) SetStaticField(name string, value interface{}) {
 
 type formatLogEvent func(
 	flags int,
-	id string,
 	level LogLevelName,
 	description string,
 	staticFields map[string]string,
@@ -436,7 +427,7 @@ type formatLogEvent func(
 
 // Format is "SEVERITY | Description [| k1='v1' k2='v2' k3=]"
 // with key/value pairs being optional, depending on whether args are provided
-func formatLogEventAsPlainText(flags int, id string, level LogLevelName, description string, staticFields map[string]string, args ...interface{}) string {
+func formatLogEventAsPlainText(flags int, level LogLevelName, description string, staticFields map[string]string, args ...interface{}) string {
 	// A full log statement is <id> | <severity> | <description> | <keys and values>
 	items := make([]string, 0, 8)
 
@@ -448,12 +439,8 @@ func formatLogEventAsPlainText(flags int, id string, level LogLevelName, descrip
 
 	items = append(items, string(level))
 
-	if id != "" {
-		items = append(items, id)
-	}
-
-	items = append(items, description)
-
+	// Combine args and staticFields, allowing args to override staticFields.
+	// But don't use yet, just use it for ID first.
 	if len(args)+len(staticFields) > 0 {
 		// Prefix with static fields, but make sure to allow args to override static.
 		for key, value := range staticFields {
@@ -469,9 +456,25 @@ func formatLogEventAsPlainText(flags int, id string, level LogLevelName, descrip
 				args = append([]interface{}{key, value}, args...)
 			}
 		}
-
-		items = append(items, expandKeyValuePairs(args))
 	}
+
+	// Grab ID from args.
+	var id string
+	for i, arg := range args {
+		if i%2 == 0 && fmt.Sprintf("%v", arg) == "id" && i < len(args)-1 {
+			// Set id and remove from fields
+			id = fmt.Sprintf("%v", args[i+1])
+			args = append(args[:i], args[i+2:])
+			break
+		}
+	}
+	if id != "" {
+		items = append(items, id)
+	}
+
+	items = append(items, description)
+
+	items = append(items, expandKeyValuePairs(args))
 
 	return strings.Join(items, " | ")
 }
@@ -500,11 +503,10 @@ func expandKeyValuePairs(keyValuePairs []interface{}) string {
 	return strings.Join(kvPairs, " ")
 }
 
-func formatLogEventAsJson(flags int, name string, level LogLevelName, msg string, staticFields map[string]string, extraFields ...interface{}) string {
+func formatLogEventAsJson(flags int, level LogLevelName, msg string, staticFields map[string]string, extraFields ...interface{}) string {
 	entry := jsonLogEntry{
 		Timestamp: time.Now().String(),
 		Level:     level,
-		Name:      name,
 		Message:   msg,
 	}
 
@@ -539,7 +541,6 @@ func formatLogEventAsJson(flags int, name string, level LogLevelName, msg string
 type jsonLogEntry struct {
 	Timestamp string            `json:"ts"`
 	Level     LogLevelName      `json:"lvl"`
-	Name      string            `json:"name,omitempty"`
 	Message   string            `json:"msg,omitempty"`
 	Fields    map[string]string `json:"fields,omitempty"`
 }

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -62,16 +62,16 @@ var _ = Describe("Logging functions", func() {
 				Expect(entry.Level).To(Equal(LevelErrorName))
 			})
 
-			It("has a name", func() {
-				Expect(entry.Name).To(Equal("id"))
-			})
-
 			It("has a message", func() {
 				Expect(entry.Message).To(Equal("oh no"))
 			})
 
 			It("has fields", func() {
 				Expect(entry.Fields).To(BeEmpty())
+			})
+
+			It("has an id field", func() {
+				Expect(entry.Fields).To(HaveKeyWithValue("id", "id"))
 			})
 		})
 


### PR DESCRIPTION
• `Logger` interface now only has public methods, so external packages can conform to it
• package level logging fns now just use `DefaultLogger`
• no more bare global variables for state, use fns on `DefaultLogger` like a normal person
• `"id"` is now set as a `keysAndValues` thing

@kevin-cantwell @kjsteuer @aviflax 