### PR TITLE
Simplify interface by removing ID as explicit arg

### DIFF
--- a/log/logging.go
+++ b/log/logging.go
@@ -134,13 +134,13 @@ func SetPrefix(prefix string) {
 // Fatal outputs a severe error message just before terminating the process.
 // Use judiciously.
 func Fatal(id, description string, keysAndValues ...interface{}) {
-	keysAndValues = append([]interface{}{"id", id}, keysAndValues...)
+	keysAndValues = append([]interface{}{"golog_id", id}, keysAndValues...)
 	DefaultLogger.Fatal(description, keysAndValues...)
 }
 
 // Error outputs an error message with an optional list of key/value pairs.
 func Error(id, description string, keysAndValues ...interface{}) {
-	keysAndValues = append([]interface{}{"id", id}, keysAndValues...)
+	keysAndValues = append([]interface{}{"golog_id", id}, keysAndValues...)
 	DefaultLogger.Error(description, keysAndValues...)
 }
 
@@ -149,7 +149,7 @@ func Error(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelWarn, calling this method will yield no
 // side effects.
 func Warn(id, description string, keysAndValues ...interface{}) {
-	keysAndValues = append([]interface{}{"id", id}, keysAndValues...)
+	keysAndValues = append([]interface{}{"golog_id", id}, keysAndValues...)
 	DefaultLogger.Warn(description, keysAndValues...)
 }
 
@@ -158,7 +158,7 @@ func Warn(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelInfo, calling this method will yield no
 // side effects.
 func Info(id, description string, keysAndValues ...interface{}) {
-	keysAndValues = append([]interface{}{"id", id}, keysAndValues...)
+	keysAndValues = append([]interface{}{"golog_id", id}, keysAndValues...)
 	DefaultLogger.Info(description, keysAndValues...)
 }
 
@@ -167,7 +167,7 @@ func Info(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelDebug, calling this method will yield no
 // side effects.
 func Debug(id, description string, keysAndValues ...interface{}) {
-	keysAndValues = append([]interface{}{"id", id}, keysAndValues...)
+	keysAndValues = append([]interface{}{"golog_id", id}, keysAndValues...)
 	DefaultLogger.Debug(description, keysAndValues...)
 }
 
@@ -176,7 +176,7 @@ func Debug(id, description string, keysAndValues ...interface{}) {
 // If LogLevel is set below LevelTrace, calling this method will yield no
 // side effects.
 func Trace(id, description string, keysAndValues ...interface{}) {
-	keysAndValues = append([]interface{}{"id", id}, keysAndValues...)
+	keysAndValues = append([]interface{}{"golog_id", id}, keysAndValues...)
 	DefaultLogger.Trace(description, keysAndValues...)
 }
 
@@ -260,7 +260,7 @@ func New(conf Config, staticKeysAndValues ...interface{}) Logger {
 	// Set 'ID' config as a static field, but before reading the varargs suplied
 	// fields, so that they can override the config.
 	if conf.ID != "" {
-		staticArgs["id"] = conf.ID
+		staticArgs["golog_id"] = conf.ID
 	}
 
 	// Do this after handling prefix, so that individual loggers can override
@@ -462,7 +462,7 @@ func formatLogEventAsPlainText(flags int, level LogLevelName, description string
 	// Grab ID from args.
 	var id string
 	for i, arg := range args {
-		if i%2 == 0 && fmt.Sprintf("%v", arg) == "id" && i < len(args)-1 {
+		if i%2 == 0 && fmt.Sprintf("%v", arg) == "golog_id" && i < len(args)-1 {
 			// Set id and remove from fields
 			id = fmt.Sprintf("%v", args[i+1])
 			args = append(args[:i], args[i+2:]...)

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -62,16 +62,12 @@ var _ = Describe("Logging functions", func() {
 				Expect(entry.Level).To(Equal(LevelErrorName))
 			})
 
-			It("has a name", func() {
-				Expect(entry.Name).To(Equal("id"))
-			})
-
 			It("has a message", func() {
 				Expect(entry.Message).To(Equal("oh no"))
 			})
 
-			It("has fields", func() {
-				Expect(entry.Fields).To(BeEmpty())
+			It("has an id field", func() {
+				Expect(entry.Fields).To(HaveKeyWithValue("id", "id"))
 			})
 		})
 
@@ -363,7 +359,7 @@ var _ = Describe("Logging functions", func() {
 			Describe("Package level Fatal()", func() {
 				BeforeEach(func() {
 					initLogging()
-					Level = LogLevel(-1)
+					SetLevel(LogLevel(-1))
 
 					didExit = false
 					exitCode = 0
@@ -385,7 +381,7 @@ var _ = Describe("Logging functions", func() {
 
 			Describe("Logger Fatal()", func() {
 				BeforeEach(func() {
-					Level = LogLevel(-1)
+					SetLevel(LogLevel(-1))
 					logger := NewDefault()
 
 					output = new(bytes.Buffer)
@@ -813,7 +809,7 @@ var _ = Describe("Logging functions", func() {
 	Context("Using package level logging", func() {
 		BeforeEach(func() {
 			output = new(bytes.Buffer)
-			Level = LevelTrace
+			SetLevel(LevelTrace)
 			SetTimestampFlags(FlagsNone)
 			SetOutput(output)
 		})
@@ -890,7 +886,7 @@ var _ = Describe("Logging functions", func() {
 			})
 
 			It("should not output anything if log level is lower than LevelWarn", func() {
-				Level = LevelError
+				SetLevel(LevelError)
 				Warn("", "Not all those who wander are lost.")
 
 				Expect(output.String()).To(BeEmpty())
@@ -905,7 +901,7 @@ var _ = Describe("Logging functions", func() {
 			})
 
 			It("should not output anything if log level is lower than LevelInfo", func() {
-				Level = LevelWarn
+				SetLevel(LevelWarn)
 				Info("", "Not all those who wander are lost.")
 
 				Expect(output.String()).To(BeEmpty())
@@ -920,7 +916,7 @@ var _ = Describe("Logging functions", func() {
 			})
 
 			It("should not output anything if log level is lower than LevelDebug", func() {
-				Level = LevelInfo
+				SetLevel(LevelInfo)
 				Debug("", "Not all those who wander are lost.")
 
 				Expect(output.String()).To(BeEmpty())
@@ -935,7 +931,7 @@ var _ = Describe("Logging functions", func() {
 			})
 
 			It("should not output anything if log level is lower than LevelTrace", func() {
-				Level = LevelInfo
+				SetLevel(LevelInfo)
 				Trace("", "Not all those who wander are lost.")
 
 				Expect(output.String()).To(BeEmpty())

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Logging functions", func() {
 			})
 
 			It("has an id field", func() {
-				Expect(entry.Fields).To(HaveKeyWithValue("id", "id"))
+				Expect(entry.Fields).To(HaveKeyWithValue("golog_id", "id"))
 			})
 		})
 


### PR DESCRIPTION
• `Logger` interface now only has public methods, so external packages can conform to it
• package level logging fns now just use `DefaultLogger`
• no more bare global variables for state, use fns on `DefaultLogger` like a normal person
• `"id"` is now set as a `keysAndValues` thing

@kevin-cantwell @kjsteuer @aviflax 